### PR TITLE
Bump markdownlint to v0.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "eslint-plugin-standard": "^4.0.0",
     "gulp": "^4.0.0",
     "jest": "^24.7.1",
-    "markdownlint": "^0.13.0"
+    "markdownlint": "^0.25.1"
   },
   "peerDependencies": {
-    "markdownlint": "^0.13.0"
+    "markdownlint": "^0.25.1"
   },
   "dependencies": {
     "plugin-error": "^1.0.1",


### PR DESCRIPTION
This PR bumps `markdownlint` to the most recently-published version, v0.25.1.